### PR TITLE
chore: upgrade skillflag to 0.1.4, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SimpleDoc
 
+[![npm version](https://img.shields.io/npm/v/@simpledoc/simpledoc.svg)](https://www.npmjs.com/package/@simpledoc/simpledoc)
+[![npm downloads](https://img.shields.io/npm/dm/@simpledoc/simpledoc.svg)](https://www.npmjs.com/package/@simpledoc/simpledoc)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 > Lightweight standard for organizing Markdown documentation in codebases
 
 SimpleDoc defines a small set of rules for the naming and placement of Markdown files in a codebase, agnostic of any documentation framework.
@@ -40,10 +44,16 @@ Configuration for tooling can be shared in `simpledoc.json` and overridden per-u
 
 ## Install
 
-Install the bundled agent skill + `AGENTS.md` instructions (no doc migrations):
+Install the bundled agent skill (interactive wizard picks your agent and scope):
 
 ```bash
-npx -y @simpledoc/simpledoc install
+npx -y @simpledoc/simpledoc --skill install simpledoc
+```
+
+Or install without interaction:
+
+```bash
+npx -y @simpledoc/simpledoc --skill install simpledoc --agent codex --scope repo
 ```
 
 ## Migrate

--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ Install the bundled agent skill (interactive wizard picks your agent and scope):
 npx -y @simpledoc/simpledoc --skill install simpledoc
 ```
 
-Or install without interaction:
-
-```bash
-npx -y @simpledoc/simpledoc --skill install simpledoc --agent codex --scope repo
-```
-
 ## Migrate
 
 Run the migrator from the repo root to rename/move docs and add frontmatter as needed:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "commander": "^11.0.0",
-        "skillflag": "^0.1.3"
+        "skillflag": "^0.1.4"
       },
       "bin": {
         "simpledoc": "dist/bin/simpledoc.js"
@@ -3690,11 +3690,12 @@
       "license": "MIT"
     },
     "node_modules/skillflag": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/skillflag/-/skillflag-0.1.3.tgz",
-      "integrity": "sha512-hMMFarrI8KhOUsSjtl7/8tvkI9du0lp1ZXyV+aL4/wzmpI0FxBFs0PkRNuu0MecX9LXXb8mYUMyiDhTLCuI7Cw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/skillflag/-/skillflag-0.1.4.tgz",
+      "integrity": "sha512-egFg+XCF5sloOWdtzxZivTX7n4UDj5pxQoY33wbT8h+YSDjMQJ76MZUg2rXQIBXmIDtlZhLgirS1g/3R5/qaHA==",
       "license": "MIT",
       "dependencies": {
+        "@clack/prompts": "^1.0.1",
         "tar-stream": "^3.1.7"
       },
       "bin": {
@@ -3703,6 +3704,27 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/skillflag/node_modules/@clack/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/skillflag/node_modules/@clack/prompts": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.1.tgz",
+      "integrity": "sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.0.1",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@clack/prompts": "^0.11.0",
     "commander": "^11.0.0",
-    "skillflag": "^0.1.3"
+    "skillflag": "^0.1.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
- Upgrade skillflag from 0.1.3 to 0.1.4 (interactive wizard, --help, single flags)
- Update install section to use `--skill install simpledoc` (interactive wizard)
- Add npm version, downloads, and license badges